### PR TITLE
perf: optimize memory metrics collection and set default refresh interval to 2000ms

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
 				},
 				"monitor-pro.refresh-interval": {
 					"type": "number",
-					"default": 3000,
+					"default": 2000,
 					"description": "%config.refresh-interval%"
 				},
 				"monitor-pro.diskSpace": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	"icon": "assets/icon.png",
 	"version": "0.6.0",
 	"engines": {
-		"vscode": "1.104.1"
+		"vscode": "^1.104.1"
 	},
 	"categories": [
 		"Other"

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,12 +1,14 @@
 import { workspace } from "vscode";
 import { MetricsExist } from "./constants";
 export const getRefreshInterval = () =>
-	workspace.getConfiguration().get<number>("monitor-pro.refresh-interval") ??
-	3000;
+    workspace.getConfiguration().get<number>("monitor-pro.refresh-interval") ??
+    2000;
 
 export const getMetrics = () =>
-	workspace.getConfiguration().get("monitor-pro.metrics") as MetricsExist[];
+    workspace.getConfiguration().get("monitor-pro.metrics") as MetricsExist[];
 export const getDiskSpaceConfig = () =>
-	workspace.getConfiguration().get<string[]>("monitor-pro.diskSpace") ?? ["/"];
+    workspace.getConfiguration().get<string[]>("monitor-pro.diskSpace") ?? [
+        "/",
+    ];
 
 export { MetricsExist };

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -2,11 +2,10 @@ import { workspace } from "vscode";
 import { MetricsExist } from "./constants";
 export const getRefreshInterval = () =>
 	workspace.getConfiguration().get<number>("monitor-pro.refresh-interval") ??
-	1000;
+	3000;
 
-export const getMetrics = workspace
-	.getConfiguration()
-	.get("monitor-pro.metrics") as MetricsExist[];
+export const getMetrics = () =>
+	workspace.getConfiguration().get("monitor-pro.metrics") as MetricsExist[];
 export const getDiskSpaceConfig = () =>
 	workspace.getConfiguration().get<string[]>("monitor-pro.diskSpace") ?? ["/"];
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,35 +1,44 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
-import { workspace, ExtensionContext } from "vscode";
+import { ExtensionContext, window } from "vscode";
 import { powerShellRelease, powerShellStart } from "systeminformation";
 import { getRefreshInterval } from "./configuration";
 import { Metric, getEnabledMetrics } from "./metricsInit";
 import I18n from "./i18n";
 
-let intervalIds: NodeJS.Timeout;
+const log = window.createOutputChannel("Monitor Pro", { log: true });
+
+let timeoutId: NodeJS.Timeout;
 let metrics: Metric[] = [];
 
-// workspace.onDidChangeConfiguration(() => {
-// 	deactivate();
-// 	activate();
-// });
-
 export const activate = async (ctx: ExtensionContext) => {
+	log.info("activate() start");
 	if (process.platform === "win32") {
 		powerShellStart();
 	}
-	I18n.init(ctx.extensionPath);
+	try {
+		I18n.init(ctx.extensionPath);
+		log.info("I18n.init OK");
+	} catch (e) {
+		log.error("I18n.init FAILED: " + String(e));
+	}
 	metrics.forEach((x) => x.dispose());
 	metrics = getEnabledMetrics();
-	const updateBarsText = async () =>
-		await Promise.all(metrics.map((x) => x.update()));
-	intervalIds = setInterval(updateBarsText, getRefreshInterval());
+	log.info(`metrics created: ${metrics.length}`);
+	const scheduleUpdate = async () => {
+		try {
+			await Promise.all(metrics.map((x) => x.update()));
+			// log.info("update cycle OK");
+		} catch (e) {
+			log.error("update cycle FAILED: " + String(e));
+		}
+		timeoutId = setTimeout(scheduleUpdate, getRefreshInterval());
+	};
+	scheduleUpdate();
 };
 
 export const deactivate = () => {
 	if (process.platform === "win32") {
 		powerShellRelease();
 	}
-	clearInterval(intervalIds);
+	clearTimeout(timeoutId);
 	metrics.forEach((x) => x.dispose());
 };

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,4 +1,5 @@
 import * as SI from "systeminformation";
+import os from "os";
 import byteFormat from "./byteFormat";
 import { MetricCtrProps } from "./constants";
 import { getDiskSpaceConfig } from "./configuration";
@@ -24,6 +25,22 @@ const pretty = (bytes: number, option: any = {}): string => {
 	});
 };
 
+let _memPromise: Promise<SI.Systeminformation.MemData> | null = null;
+const getMem = (): Promise<SI.Systeminformation.MemData> => {
+	if (!_memPromise) {
+		_memPromise = SI.mem().finally(() => { _memPromise = null; });
+	}
+	return _memPromise;
+};
+
+let _osPromise: Promise<SI.Systeminformation.OsData> | null = null;
+const getOsInfo = (): Promise<SI.Systeminformation.OsData> => {
+	if (!_osPromise) {
+		_osPromise = SI.osInfo();
+	}
+	return _osPromise;
+};
+
 const cpuText = async () => {
 	const cl = await SI.currentLoad();
 	return `$(pulse)${cl.currentLoad.toLocaleString(undefined, {
@@ -33,7 +50,7 @@ const cpuText = async () => {
 };
 
 const memActiveText = async () => {
-	const m = await SI.mem();
+	const m = await getMem();
 	let active, total;
 	if (Number(pretty(m.total, { suffix: false })) < 100) {
 		active = pretty(m.active, {
@@ -56,7 +73,7 @@ const memActiveText = async () => {
 };
 
 const memUsedText = async () => {
-	const m = await SI.mem();
+	const m = await getMem();
 	let used, total;
 	if (Number(pretty(m.total, { suffix: false })) < 100) {
 		used = pretty(m.used, {
@@ -122,7 +139,7 @@ const cpuTempText = async () => {
 };
 
 const osDistroText = async () => {
-	const os = await SI.osInfo();
+	const os = await getOsInfo();
 	return `${os.distro}`;
 };
 
@@ -149,10 +166,10 @@ const diskSpaceText = async () => {
 };
 
 const uptimeText = async () => {
-	const uptime = await SI.time();
-	const days = Math.floor(uptime.uptime / (24 * 3600));
-	const hours = Math.floor((uptime.uptime % (24 * 3600)) / 3600);
-	const minutes = Math.floor((uptime.uptime % 3600) / 60);
+	const uptime = os.uptime();
+	const days = Math.floor(uptime / (24 * 3600));
+	const hours = Math.floor((uptime % (24 * 3600)) / 3600);
+	const minutes = Math.floor((uptime % 3600) / 60);
 	return `$(clock) ${days}d ${hours}h ${minutes}m`;
 };
 

--- a/src/metricsInit.ts
+++ b/src/metricsInit.ts
@@ -47,13 +47,13 @@ const newBarItem = ({ priority,section }: { priority: number, section: MetricsEx
 	return sbi;
 };
 
-const allMetrics = getMetrics.flatMap((x) => {
-	const metric = metrics.find((m) => m.section === x);
-	if(metric) {
-		return new Metric(metric);
-	} else {
+export const getEnabledMetrics = () => {
+	const enabledSections = getMetrics() ?? [];
+	return enabledSections.flatMap((x) => {
+		const metric = metrics.find((m) => m.section === x);
+		if (metric) {
+			return new Metric(metric).init(enabledSections.indexOf(x));
+		}
 		return [];
-	}
-});
-export const getEnabledMetrics = () =>
-	allMetrics.flatMap((x, index) => x.init(index) || []);
+	});
+};


### PR DESCRIPTION
- Optimized memory metric collection in `src/metrics.ts`
  - Introduced cached `getMem()` and `getOsInfo()` helpers to avoid repeated `systeminformation` calls for `mem()` and `osInfo()`.
  - Switched uptime calculation to use `os.uptime()` to reduce overhead.
- Improved extension startup and update scheduling in `src/extension.ts`
  - Changed periodic updates from `setInterval` to recursive `setTimeout` for more stable scheduling.
  - Added activation logging and exception handling to reduce extension loading failure risk.
- Adjusted default refresh interval
  - Updated `monitor-pro.refresh-interval` default from `3000ms` to `2000ms` in both `package.json` and `src/configuration.ts` for better responsiveness while keeping resource use under control.
- Compatibility improvement
  - Updated VS Code engine requirement in `package.json` to `^1.104.1` for broader compatibility.
