### PR TITLE
fix(deps): update systeminformation to 5.31.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
   },
   "dependencies": {
     "source-map-support": "^0.5.21",
-    "systeminformation": "5.31.6"
+    "systeminformation": "5.31.7"
   },
   "description": "Monitor all the resources you care about.",
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.5.21
         version: 0.5.21
       systeminformation:
-        specifier: 5.31.6
-        version: 5.31.6
+        specifier: 5.31.7
+        version: 5.31.7
     devDependencies:
       '@types/mocha':
         specifier: 10.0.10
@@ -2000,8 +2000,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  systeminformation@5.31.6:
-    resolution: {integrity: sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==}
+  systeminformation@5.31.7:
+    resolution: {integrity: sha512-/8NC53e5nP9nmhn42/ncdOkyJnOoue/Vy+tJOyUGd1Yv66G069wK4rrziwhrqDETgk78CudTQupw5z19S5uoZw==}
     engines: {node: '>=8.0.0'}
     os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
     hasBin: true
@@ -4334,7 +4334,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  systeminformation@5.31.6: {}
+  systeminformation@5.31.7: {}
 
   table@6.9.0:
     dependencies:


### PR DESCRIPTION
Bumps `systeminformation` from 5.31.6 to 5.31.7.

### Security fix

Resolves **GHSA-5xpp-75jx-m839** (CVE-2026-50289): OS command injection in `networkInterfaces()` via crafted `interfaces(5)` content.

- Before: `systeminformation@5.31.6` (vulnerable)
- After: `systeminformation@5.31.7` (patched)

### Verification

OSV API query for `systeminformation@5.31.7` returns 0 vulnerabilities (the single advisory GHSA-5xpp-75jx-m839 is present at 5.31.6 and cleared at 5.31.7).

### Changes

- `package.json`: update `systeminformation` version
- `pnpm-lock.yaml`: updated lockfile (only `systeminformation` lines changed)