### PR TITLE
🐛 fix: clamp battery charge and health percentages

### DIFF
--- a/go-backend/handlers.go
+++ b/go-backend/handlers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"net/http"
 	"runtime"
 	"strings"
@@ -87,13 +88,10 @@ func getBatteryData() batteryInfo {
 
 	percent := 0.0
 	if bat.Full > 0 {
-		percent = (bat.Current / bat.Full) * 100
+		percent = clampBatteryPercent((bat.Current / bat.Full) * 100)
 	}
 
-	health := 0.0
-	if bat.Design > 0 {
-		health = (bat.Full / bat.Design) * 100
-	}
+	health := batteryHealthPercent(bat.Full, bat.Design)
 
 	return batteryInfo{
 		HasBattery: true,
@@ -106,6 +104,24 @@ func getBatteryData() batteryInfo {
 		Design:     bat.Design,
 		Voltage:    bat.Voltage,
 	}
+}
+
+func batteryHealthPercent(full, design float64) float64 {
+	if design <= 0 {
+		return 0
+	}
+	// Report health as a percentage even when measured capacity exceeds the design rating.
+	return clampBatteryPercent((full / design) * 100)
+}
+
+func clampBatteryPercent(percent float64) float64 {
+	if math.IsNaN(percent) || percent < 0 {
+		return 0
+	}
+	if percent > 100 {
+		return 100
+	}
+	return percent
 }
 
 func usageWithTimeout(mountpoint string) *disk.UsageStat {

--- a/go-backend/handlers_test.go
+++ b/go-backend/handlers_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -18,6 +19,46 @@ func checkSuccess(t *testing.T, body []byte) {
 	}
 	if resp.Data == nil {
 		t.Fatal("expected Data to be non-nil")
+	}
+}
+
+func TestClampBatteryPercent(t *testing.T) {
+	tests := []struct {
+		name  string
+		input float64
+		want  float64
+	}{
+		{name: "within range", input: 75, want: 75},
+		{name: "above range", input: 101, want: 100},
+		{name: "below range", input: -1, want: 0},
+		{name: "not a number", input: math.NaN(), want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := clampBatteryPercent(tt.input); got != tt.want {
+				t.Fatalf("clampBatteryPercent(%v) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBatteryHealthPercent(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		full, design, want float64
+	}{
+		{"above design capacity", 5050, 5000, 100},
+		{"degraded battery", 4000, 5000, 80},
+		{"zero design capacity", 5000, 0, 0},
+		{"negative design capacity", 5000, -1, 0},
+		{"invalid capacity", math.NaN(), 5000, 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := batteryHealthPercent(tt.full, tt.design); got != tt.want {
+				t.Fatalf("batteryHealthPercent(%v, %v) = %v, want %v", tt.full, tt.design, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -381,6 +381,7 @@
     "package:vsix:win32-x64": "pnpm run go:build:win32-x64 && pnpm exec vsce package --no-dependencies --target win32-x64 -o monitor-pro-$(node -p \"require('./package.json').version\")-win32-x64.vsix",
     "pretest": "pnpm run compile-tests && pnpm run compile && pnpm run lint",
     "test": "node ./out/test/runTest.js",
+    "test:unit": "pnpm run compile-tests && mocha \"out/**/*.test.js\"",
     "vscode:prepublish": "pnpm run package",
     "watch": "npm-run-all -p watch:*",
     "watch-tests": "tsc -p . -w --outDir out",

--- a/src/batteryPercent.test.ts
+++ b/src/batteryPercent.test.ts
@@ -1,0 +1,77 @@
+import { strict as assert } from "assert";
+import {
+  clampBatteryPercent,
+  normalizeBatteryPercentages,
+} from "./batteryPercent";
+
+// Mirrors the health calculation used by the systeminformation and mactop
+// data sources: (maxCapacity / designedCapacity) * 100.
+function health(full: number, design: number): number {
+  if (!full || !design) {
+    return 0;
+  }
+  return (full / design) * 100;
+}
+
+describe("clampBatteryPercent", () => {
+  const cases: Array<[string, number, number]> = [
+    ["above 100 clamps to 100", 101, 100],
+    ["far above 100 clamps to 100", 150, 100],
+    ["exactly 100 stays 100", 100, 100],
+    ["within range stays unchanged", 75, 75],
+    ["exactly 0 stays 0", 0, 0],
+    ["negative clamps to 0", -5, 0],
+    ["NaN clamps to 0", Number.NaN, 0],
+  ];
+  for (const [name, input, expected] of cases) {
+    it(name, () => {
+      assert.equal(clampBatteryPercent(input), expected);
+    });
+  }
+});
+
+describe("battery health display", () => {
+  const cases: Array<[string, number, number, number]> = [
+    ["full capacity above design shows 100", 5300, 5000, 100],
+    ["full capacity equals design shows 100", 5000, 5000, 100],
+    ["degraded battery shows 80", 4000, 5000, 80],
+  ];
+  for (const [name, full, design, expected] of cases) {
+    it(name, () => {
+      assert.equal(clampBatteryPercent(health(full, design)), expected);
+    });
+  }
+
+  it("missing capacity shows 0", () => {
+    assert.equal(clampBatteryPercent(health(0, 5000)), 0);
+  });
+
+  it("zero design capacity shows 0", () => {
+    assert.equal(clampBatteryPercent(health(5000, 0)), 0);
+  });
+});
+
+describe("normalizeBatteryPercentages", () => {
+  it("clamps percent and health while preserving raw capacity", () => {
+    const battery = {
+      designedCapacity: 5000,
+      maxCapacity: 5300,
+      currentCapacity: 2500,
+      percent: 101,
+      health: 150,
+    };
+    normalizeBatteryPercentages(battery);
+    assert.equal(battery.percent, 100);
+    assert.equal(battery.health, 100);
+    assert.equal(battery.designedCapacity, 5000);
+    assert.equal(battery.maxCapacity, 5300);
+    assert.equal(battery.currentCapacity, 2500);
+  });
+
+  it("leaves valid values unchanged", () => {
+    const battery = { percent: 42, health: 80 };
+    normalizeBatteryPercentages(battery);
+    assert.equal(battery.percent, 42);
+    assert.equal(battery.health, 80);
+  });
+});

--- a/src/batteryPercent.ts
+++ b/src/batteryPercent.ts
@@ -1,0 +1,23 @@
+/**
+ * Battery display percentages are clamped to 0-100 in this common layer, which
+ * every backend (Go, systeminformation, mactop) flows through before reaching
+ * the UI. Raw capacity values (designedCapacity, maxCapacity, currentCapacity)
+ * are never modified - only the derived display values are normalized.
+ */
+export function clampBatteryPercent(value: number): number {
+  if (!Number.isFinite(value) || value < 0) {
+    return 0;
+  }
+  if (value > 100) {
+    return 100;
+  }
+  return value;
+}
+
+export function normalizeBatteryPercentages(battery: {
+  percent: number;
+  health: number;
+}): void {
+  battery.percent = clampBatteryPercent(battery.percent);
+  battery.health = clampBatteryPercent(battery.health);
+}

--- a/src/systemData.ts
+++ b/src/systemData.ts
@@ -4,6 +4,7 @@ import { l10n } from "vscode";
 import type { DataSource } from "./dataSource";
 import { SIDataSource } from "./dataSource";
 import { getLogger } from "./logger";
+import { normalizeBatteryPercentages } from "./batteryPercent";
 import type { MetricsExist } from "./constants";
 import type { GpuCard } from "./gpuUtil";
 
@@ -269,6 +270,9 @@ class SystemDataProvider {
           return;
         }
         this._consecutiveFailures = 0;
+        // Common normalization for every data source (Go, systeminformation,
+        // mactop) before the snapshot reaches the UI.
+        normalizeBatteryPercentages(data.battery);
         data.unavailableMetrics = this.computeUnavailableMetrics(data);
         this._snapshot = data;
 
@@ -363,6 +367,8 @@ class SystemDataProvider {
       this._worker.on("message", (msg: any) => {
         if (msg.type === "data") {
           const data = msg.data as SystemSnapshot;
+          // Apply the same common battery normalization to worker snapshots.
+          normalizeBatteryPercentages(data.battery);
           data.unavailableMetrics = this.computeUnavailableMetrics(data);
           this._snapshot = data;
 


### PR DESCRIPTION
Clamp battery charge and health percentages to 0-100 in the common TypeScript layer so the behavior is consistent across every backend (Go, systeminformation, mactop). Raw capacity values (designCapacity, maxCapacity, currentCapacity) remain unchanged.

Fixes #481.

## Where the clamp lives

src/systemData.ts is the first common layer every data source flows through before the snapshot reaches the UI (status bar, metrics, webview, worker). 
ormalizeBatteryPercentages() clamps attery.percent and attery.health there, so:

- Windows/Linux Go backend values are clamped at the backend and re-clamped harmlessly in the common layer.
- macOS mactop and systeminformation backends (where health is computed as maxCapacity / designedCapacity * 100 and can exceed 100) are now clamped too.
- Raw telemetry/capacity stays intact; only displayed percentages are bounded.

## Tests

- Go suite covers clampBatteryPercent/atteryHealthPercent (above-design capacity, degraded capacity, zero/invalid capacity, NaN).
- New TypeScript unit tests (pnpm run test:unit) cover health (5300/5000 -> 100, 5000/5000 -> 100, 4000/5000 -> 80, missing/zero capacity -> 0), charge bounds (101/150 -> 100, 100 -> 100, negative -> 0, NaN -> 0), and verify raw capacity values are preserved after normalization.

Validation: pnpm run check-types, pnpm run test:unit, pnpm run lint (no new warnings), go test ./... and go vet pass.
